### PR TITLE
Return request response

### DIFF
--- a/src/RequestRateLimiter.mjs
+++ b/src/RequestRateLimiter.mjs
@@ -66,8 +66,9 @@ export default class RequestRateLimiter {
             await this.bucket.throttle();
 
 
-            await this.executeRequest(requestConfig).then(() => {
+            return await this.executeRequest(requestConfig).then((response) => {
                 log.debug(`Request was sucessfull`);
+                return response;
             }).catch(async (err) => {
                 if (err instanceof BackoffError) {
                     log.debug(`Backing off for ${this.backoffTime}`);

--- a/test/100.000-limiter.mjs
+++ b/test/100.000-limiter.mjs
@@ -11,6 +11,15 @@ section('Rate Limiter', (section) => {
     });
 
 
+    section.test('return request response', async() => {
+        const limiter = new RequestRateLimiter();
+        limiter.setRequestHandler(new MockRequestHandler());
+
+        const response = await limiter.request({});
+        assert.deepStrictEqual(response, { status: 'good' });
+    });
+
+
     section.test('enqueue one request', async() => {
         const limiter = new RequestRateLimiter();
         limiter.setRequestHandler(new MockRequestHandler());


### PR DESCRIPTION
Hi @linaGirl,

There is a bug with the new version of request-rate-limiter. The `limiter.request` doesn't return the request response at the moment. This PR fixes that issue. I added the test for it as well. Can you have a look at it. Thanks.